### PR TITLE
Fixing broken Wikipedia link

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ layout: home
 
 From [Wikipedia](https://en.wikipedia.org/wiki/MLOps):
 
-> MLOps (a compound of “machine learning” and “operations”) is a practice for collaboration and communication between data scientists and operations professionals to help manage production ML (or deep learning) lifecycle.[1] Similar to the DevOps or DataOps approaches, MLOps looks to increase automation and improve the quality of production ML while also focusing on business and regulatory requirements. While MLOps also started as a set of best practices, it is slowly evolving into an independent approach to ML lifecycle management. MLOps applies to the entire lifecycle - from integrating with model generation (software development lifecycle, continuous integration/continuous delivery), orchestration, and deployment, to health, diagnostics, governance, and business metrics.
+> MLOps (a compound of “machine learning” and “operations”) is a practice for collaboration and communication between data scientists and operations professionals to help manage production ML (or deep learning) [lifecycle](https://www.aitrends.com/machine-learning/mlops-not-just-ml-business-new-competitive-frontier/). Similar to the DevOps or DataOps approaches, MLOps looks to increase automation and improve the quality of production ML while also focusing on business and regulatory requirements. While MLOps also started as a set of best practices, it is slowly evolving into an independent approach to ML lifecycle management. MLOps applies to the entire lifecycle - from integrating with model generation (software development lifecycle, continuous integration/continuous delivery), orchestration, and deployment, to health, diagnostics, governance, and business metrics.
 
 ## How Can GitHub Help With MLOps?
 


### PR DESCRIPTION
Thanks for creating this! Hope you don't mind that I saw a broken Wikipedia source link for "ML lifecycle" and fixed it. 